### PR TITLE
resolved go-staticcheck errors

### DIFF
--- a/blog.go
+++ b/blog.go
@@ -26,16 +26,14 @@ func (b *botState) updateArticles() {
 
 	articleTicker := time.NewTicker(time.Hour * 72)
 	for {
-		select {
-		case <-articleTicker.C:
-			articles, err := blog.Articles(http.DefaultClient)
-			if err != nil {
-				log.Printf("Error querying maps: %v", err)
-				continue
-			}
-
-			b.articles = articles
+		<-articleTicker.C
+		articles, err := blog.Articles(http.DefaultClient)
+		if err != nil {
+			log.Printf("Error querying maps: %v", err)
+			continue
 		}
+
+		b.articles = articles
 	}
 }
 

--- a/doc.go
+++ b/doc.go
@@ -42,31 +42,30 @@ var (
 func (b *botState) gcInteractionData() {
 	mapTicker := time.NewTicker(time.Minute * 5)
 	for {
-		select {
 		// gc interaction tokens
-		case <-mapTicker.C:
-			now := time.Now()
-			for _, data := range interactionMap {
-				if !now.After(data.created.Add(time.Minute * 5)) {
-					continue
-				}
+		<-mapTicker.C
+		now := time.Now()
+		for _, data := range interactionMap {
+			if !now.After(data.created.Add(time.Minute * 5)) {
+				continue
+			}
 
-				mu.Lock()
-				delete(interactionMap, data.id)
-				mu.Unlock()
+			mu.Lock()
+			delete(interactionMap, data.id)
+			mu.Unlock()
 
-				if data.token == "" {
-					b.state.EditMessageComplex(data.channelID, data.messageID, api.EditMessageData{
-						Components: &discord.ContainerComponents{},
-					})
-					continue
-				}
-
-				b.state.EditInteractionResponse(b.appID, data.token, api.EditInteractionResponseData{
+			if data.token == "" {
+				b.state.EditMessageComplex(data.channelID, data.messageID, api.EditMessageData{
 					Components: &discord.ContainerComponents{},
 				})
+				continue
 			}
+
+			b.state.EditInteractionResponse(b.appID, data.token, api.EditInteractionResponseData{
+				Components: &discord.ContainerComponents{},
+			})
 		}
+
 	}
 }
 
@@ -435,7 +434,6 @@ func (b *botState) handleDocsComplete(e *gateway.InteractionCreateEvent, d *disc
 		split = strings.Split(base, ".")
 		module = dir + split[0]
 	}
-	split = split[1:]
 
 	ranks := b.packageCache(module)
 	sort.Sort(ranks)

--- a/handle.go
+++ b/handle.go
@@ -123,7 +123,7 @@ func loadCommands(s *state.State, me discord.UserID, cfg configuration) error {
 			if errors.As(err, &httperr) {
 				log.Println(string(httperr.Body))
 			}
-			return fmt.Errorf("Could not register: %s, %w", c.Name, err)
+			return fmt.Errorf("could not register: %s, %w", c.Name, err)
 		}
 
 		switch c.Name {

--- a/info.go
+++ b/info.go
@@ -69,7 +69,7 @@ func (b *botState) handleInfoComponent(e *gateway.InteractionCreateEvent, data d
 				Flags: api.EphemeralResponse,
 				Embeds: &[]discord.Embed{
 					{
-						Title: fmt.Sprintf("Command Help"),
+						Title: "Command Help",
 						Fields: []discord.EmbedField{
 							{
 								Name:  "/docs",


### PR DESCRIPTION
Removed unneeded select statements in blog.go, doc.go per static check (s1000)
since only a single case is needed waiting on the channel is fine. 

value of `split` is never used after line 438 in doc.go. removed it.

changed an uppercase letter to a lowercase letter in handle.go

removed unneeded fmt.Sprintf in info.go, replaced with a literal. 

I know this is a dumb commit, but it does fix the static check errors. If I made a boo boo removing the select statements, I apologize in advance for wasting anyone's time.

